### PR TITLE
Fix actions/upload-pages-artifact version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: dist
       - id: deployment


### PR DESCRIPTION
## Summary
- update `actions/upload-pages-artifact` to v3 so deploy job works

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b1c9b5c688325bfae5885f8fe9684