### PR TITLE
Fix router base for GitHub pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>News SPA</title>
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href="./manifest.webmanifest" />
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "News SPA",
   "short_name": "News",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "description": "News app",

--- a/src/main.js
+++ b/src/main.js
@@ -10,8 +10,9 @@ const routes = [
   { path: "/settings", component: Settings },
 ];
 
+const base = window.location.pathname.replace(/\/[^/]*$/, "/");
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHashHistory(base),
   routes,
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
+  base: './',
   plugins: [
     vue(),
     VitePWA({ registerType: 'autoUpdate' })


### PR DESCRIPTION
## Summary
- load assets relative to current path
- adjust manifest start_url for subpath deploys
- detect base URL at runtime
- make build assets use relative paths

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b2299cb9883259e608b4a6db7dd28