### PR TITLE
Change news storage format

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,10 +1,11 @@
 import { openDB } from "idb";
 
-export const dbPromise = openDB("news-db", 1, {
+export const dbPromise = openDB("news-db", 2, {
   upgrade(db) {
-    if (!db.objectStoreNames.contains("news")) {
-      db.createObjectStore("news", { keyPath: "id" });
+    if (db.objectStoreNames.contains("news")) {
+      db.deleteObjectStore("news");
     }
+    db.createObjectStore("news", { keyPath: "link" });
     if (!db.objectStoreNames.contains("settings")) {
       db.createObjectStore("settings");
     }


### PR DESCRIPTION
## Summary
- parse news JSON before saving to IndexedDB
- use `link` as object store key
- load news directly from object store
- await writes and skip items missing a link

## Testing
- `npm run format`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b2813e4cc8325b1df8571a5f0846b