### PR TITLE
Add logo and clock to navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,18 @@
 <template>
   <div>
     <nav class="navbar is-light" role="navigation" aria-label="main navigation">
+      <div class="navbar-brand">
+        <router-link class="navbar-item" to="/">
+          <img :src="logo" alt="logo" />
+        </router-link>
+      </div>
       <div class="navbar-menu is-active">
         <div class="navbar-start">
           <router-link class="navbar-item" to="/">Home</router-link>
           <router-link class="navbar-item" to="/settings">Settings</router-link>
+        </div>
+        <div class="navbar-end">
+          <div class="navbar-item">{{ now }}</div>
         </div>
       </div>
     </nav>
@@ -14,6 +22,28 @@
   </div>
 </template>
 
-<script setup></script>
+<script setup>
+import { ref, onMounted, onUnmounted } from "vue";
+import logoUrl from "./assets/logo.svg";
 
-<style scoped></style>
+const logo = logoUrl;
+const now = ref("");
+let timer;
+
+onMounted(() => {
+  now.value = new Date().toLocaleTimeString();
+  timer = setInterval(() => {
+    now.value = new Date().toLocaleTimeString();
+  }, 1000);
+});
+
+onUnmounted(() => {
+  clearInterval(timer);
+});
+</script>
+
+<style scoped>
+.navbar-item img {
+  max-height: 3rem;
+}
+</style>

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="30" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#3273dc"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="white">News</text>
+</svg>


### PR DESCRIPTION
## Summary
- enhance navbar with a logo on the left
- show current time on the right

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b2ca14a308325b7cc492a8f0fd5e2